### PR TITLE
Fix: Don't include gutters that are empty, support passing null to gutter facet

### DIFF
--- a/src/Gutters.ts
+++ b/src/Gutters.ts
@@ -5,13 +5,16 @@ const GUTTER_WIDTH = 4;
 
 type Line = number;
 type Color = string;
+type Gutter = Record<Line, Color>;
 
 /** 
  * Enables a gutter to be drawn on the given line to the left
  * of the minimap, with the given color. Accepts all valid CSS
  * color values.
  */
-const GutterDecoration = Facet.define<Record<Line, Color>>({});
+const GutterDecoration = Facet.define<Gutter | null, Array<Gutter>>({
+  combine: (vals) => vals.filter(v => v && Object.keys(v).length > 0) as Array<Gutter>
+});
 
 
 /** 


### PR DESCRIPTION
If the gutter facet is used, it will currently always show, even if we return `{}` to it. We should provide the ability to return `null` or `{}` if you don't actually want to provide a gutter. This is useful if you're deriving from some state, as we do in repl-it-web, and the state may not always result in a gutter being shown.


Tested in the `dev` test harness, added three gutters, with the middle one returning `{}`: 
You can see it didn't show the middle one (or a space between the red gutter and the green gutter)
<img width="258" alt="Screen Shot 2023-07-20 at 3 32 04 PM" src="https://github.com/replit/codemirror-minimap/assets/16962017/720443f9-5c92-4c80-a9f6-3f1a788a5640">
