### PR TITLE
Update api to better support enable/disable

### DIFF
--- a/.replit
+++ b/.replit
@@ -24,3 +24,8 @@ requiredFiles = [".replit", "replit.nix", ".config"]
 XDG_CONFIG_HOME = "$REPL_HOME/.config"
 PATH = "$REPL_HOME/node_modules/.bin:$REPL_HOME/.config/npm/node_global/bin"
 npm_config_prefix = "$REPL_HOME/.config/npm/node_global"
+
+[deployment]
+run = ["tsx", "index.ts"]
+deploymentTarget = "cloudrun"
+ignorePorts = false

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -1,5 +1,7 @@
 import { Facet, combineConfig } from "@codemirror/state";
 import { DOMEventMap, EditorView } from "@codemirror/view";
+import { MinimapConfig } from ".";
+import { Gutter } from "./Gutters";
 
 type EventHandler<event extends keyof DOMEventMap> = (
   e: DOMEventMap[event],
@@ -24,14 +26,36 @@ type Options = {
    * Defaults to `always`.
    */
   showOverlay?: "always" | "mouse-over";
+
+  /** 
+   * Enables a gutter to be drawn on the given line to the left
+   * of the minimap, with the given color. Accepts all valid CSS
+   * color values.
+   */
+  gutters?: Array<Gutter>
 };
 
-const Config = Facet.define<Options, Required<Options>>({
-  combine: (configs) => {
+const Config = Facet.define<MinimapConfig | null, Required<Options>>({
+  combine: (c) => {
+    const configs: Array<Omit<MinimapConfig, 'create'>> = [];
+    for (let config of c) {
+      if (!config) {
+        continue;
+      }
+
+      const { create, gutters, ...rest } = config;
+
+      configs.push({
+        ...rest,
+        gutters: gutters ? gutters.filter(v => Object.keys(v).length > 0) : undefined,
+      });
+    }
+
     return combineConfig(configs, {
       displayText: "characters",
       eventHandlers: {},
       showOverlay: "always",
+      gutters: [],
     });
   },
 });

--- a/src/Gutters.ts
+++ b/src/Gutters.ts
@@ -1,20 +1,10 @@
-import { Facet } from "@codemirror/state";
 import { DrawContext } from "./types";
 
 const GUTTER_WIDTH = 4;
 
 type Line = number;
 type Color = string;
-type Gutter = Record<Line, Color>;
-
-/** 
- * Enables a gutter to be drawn on the given line to the left
- * of the minimap, with the given color. Accepts all valid CSS
- * color values.
- */
-const GutterDecoration = Facet.define<Gutter | null, Array<Gutter>>({
-  combine: (vals) => vals.filter(v => v && Object.keys(v).length > 0) as Array<Gutter>
-});
+export type Gutter = Record<Line, Color>;
 
 
 /** 
@@ -34,4 +24,4 @@ function drawLineGutter(gutter: Record<Line, Color>, ctx: DrawContext, lineNumbe
 }
 
 
-export { GUTTER_WIDTH, GutterDecoration, drawLineGutter }
+export { GUTTER_WIDTH, drawLineGutter }

--- a/src/LinesState.ts
+++ b/src/LinesState.ts
@@ -1,11 +1,16 @@
 import { foldEffect, foldedRanges, unfoldEffect } from "@codemirror/language";
 import { StateField, EditorState, Transaction } from "@codemirror/state";
+import { showMinimap } from ".";
 
 type Span = { from: number; to: number; folded: boolean };
 type Line = Array<Span>;
 type Lines = Array<Line>;
 
 function computeLinesState(state: EditorState): Lines {
+  if (!state.facet(showMinimap)) {
+    return [];
+  }
+
   const lines: Lines = [];
 
   const lineCursor = state.doc.iterLines();

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,8 @@ const minimapClass = ViewPlugin.fromClass(
       this.canvas = crelt("canvas") as HTMLCanvasElement;
 
       this.dom = config.create(view).dom;
-      this.dom.classList.add('cm-minimap-gutter')
+      this.dom.classList.add('cm-gutters');
+      this.dom.classList.add('cm-minimap-gutter');
 
       this.inner.appendChild(this.canvas);
       this.dom.appendChild(this.inner);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Extension } from "@codemirror/state";
+import { Facet } from "@codemirror/state";
 import { EditorView, ViewPlugin, ViewUpdate } from "@codemirror/view";
 import { Overlay } from "./Overlay";
 import { Config, Options, Scale } from "./Config";
@@ -7,7 +7,7 @@ import { SelectionState, selections } from "./selections";
 import { TextState, text } from "./text";
 import { LinesState } from "./LinesState";
 import crelt from "crelt";
-import { GUTTER_WIDTH, drawLineGutter, GutterDecoration } from "./Gutters";
+import { GUTTER_WIDTH, drawLineGutter } from "./Gutters";
 
 const Theme = EditorView.theme({
   "&": {
@@ -41,33 +41,47 @@ const WIDTH_RATIO = 6;
 
 const minimapClass = ViewPlugin.fromClass(
   class {
-    private dom: HTMLElement;
-    private inner: HTMLElement;
-    private canvas: HTMLCanvasElement;
-
-    private view: EditorView;
+    private dom: HTMLElement | undefined;
+    private inner: HTMLElement | undefined;
+    private canvas: HTMLCanvasElement | undefined;
 
     public text: TextState;
     public selection: SelectionState;
     public diagnostic: DiagnosticState;
 
-    public constructor(view: EditorView) {
-      this.view = view;
-
+    public constructor(private view: EditorView) {
       this.text = text(view);
       this.selection = selections(view);
       this.diagnostic = diagnostics(view);
 
-      this.dom = crelt("div", { class: "cm-gutters cm-minimap-gutter" });
+      if (view.state.facet(showMinimap)) {
+        this.create(view)
+      }
+    }
+
+    private create(view: EditorView) {
+      const config = view.state.facet(showMinimap)
+      if (!config) {
+        throw Error('Expected nonnull');
+      }
+
       this.inner = crelt("div", { class: "cm-minimap-inner" });
       this.canvas = crelt("canvas") as HTMLCanvasElement;
 
+      this.dom = config.create(view).dom;
+      this.dom.classList.add('cm-minimap-gutter')
+
       this.inner.appendChild(this.canvas);
       this.dom.appendChild(this.inner);
+
+      // For now let's keep this same behavior. We might want to change
+      // this in the future and have the extension figure out how to mount.
+      // Or expose some more generic right gutter api and use that
       this.view.scrollDOM.insertBefore(
         this.dom,
         this.view.contentDOM.nextSibling
       );
+
 
       for (const key in this.view.state.facet(Config).eventHandlers) {
         const handler = this.view.state.facet(Config).eventHandlers[key];
@@ -77,7 +91,25 @@ const minimapClass = ViewPlugin.fromClass(
       }
     }
 
+    private remove() {
+      if (this.dom) {
+        this.dom.remove();
+      }
+    }
+
     update(update: ViewUpdate) {
+      const prev = update.startState.facet(showMinimap);
+      const now = update.state.facet(showMinimap);
+
+      if (prev && !now) {
+        this.remove();
+        return;
+      }
+
+      if (!prev && now) {
+        this.create(update.view)
+      }
+
       this.text.update(update);
       this.selection.update(update);
       this.diagnostic.update(update);
@@ -94,6 +126,11 @@ const minimapClass = ViewPlugin.fromClass(
     }
 
     render() {
+      // If we don't have elements to draw to exit early
+      if (!this.dom || !this.canvas || !this.inner) {
+        return;
+      }
+
       this.text.beforeDraw();
 
       this.updateBoxShadow();
@@ -122,7 +159,7 @@ const minimapClass = ViewPlugin.fromClass(
         lineHeight
       );
 
-      const gutters = this.view.state.facet(GutterDecoration);
+      const gutters = this.view.state.facet(Config).gutters;
 
       for (let i = startIndex; i < endIndex; i++) {
         const lines = this.view.state.field(LinesState);
@@ -193,6 +230,10 @@ const minimapClass = ViewPlugin.fromClass(
     }
 
     private updateBoxShadow() {
+      if (!this.canvas) {
+        return;
+      }
+
       const { clientWidth, scrollWidth, scrollLeft } = this.view.scrollDOM;
 
       if (clientWidth + scrollLeft < scrollWidth) {
@@ -203,7 +244,7 @@ const minimapClass = ViewPlugin.fromClass(
     }
 
     destroy() {
-      this.dom.remove();
+      this.remove()
     }
   },
   {
@@ -225,16 +266,33 @@ const minimapClass = ViewPlugin.fromClass(
   }
 );
 
-function minimap(o: Options = {}): Extension {
-  return [
-    Theme,
-    Config.of(o),
-    LinesState,
-
-    minimapClass, // TODO, maybe can codemirror-ify this one better
-
-    Overlay,
-  ];
+export interface MinimapConfig extends Options {
+  /** 
+   * A function that creates the element that contains the minimap
+   */
+  create: (view: EditorView) => { dom: HTMLElement };
 }
 
-export { minimap, GutterDecoration as MinimapGutterDecoration };
+
+/** 
+ * Facet used to show a minimap in the right gutter of the editor using the
+ * provided configuration.
+ * 
+ * If you return `null`, a minimap will not be shown.
+ */
+const showMinimap = Facet.define<MinimapConfig | null, MinimapConfig | null>({
+  combine: (c) => c.find(o => o !== null) ?? null,
+  enables: (f) => {
+    return [
+      [
+        Config.compute([f], (s) => s.facet(f)),
+        Theme,
+        LinesState,
+        minimapClass, // TODO, codemirror-ify this one better
+        Overlay,
+      ]
+    ]
+  }
+})
+
+export { showMinimap };


### PR DESCRIPTION
There's a lot here - because I've learned a lot more about the correct way to write codemirror apis since I first wrote this.
But the key thing to look at in my opinion is the new external API.


```typescript
const extension = showMinimap.compute([...], (state) => {

    if ( /* don't render minimap */ ) {
      return null;
    }
    
    ...

    const create = (view: EditorView) => {
        // Returns a dom node that the minimap is rendered within
        ...
        return { dom }
    }

    return { 
        create /* required */,
        showOverlay /* optional */, 
        displayText /* optional */, 
        gutters /* optional */
    }
}),
```

The main benefits:
1. It is much easier to enable and disable the minimap based on changes in codemirror state. Before, it was essentially impossible, because you had to add and remove the entire extension, which is kind of an antipattern. Now, similar to tooltips, if you return null into the Facet, we don't show the minimap.
2. All the configuration is housed within one facet. Previously, there was a separate facet for registering the gutters. That didn't make much sense. It's better to have it all in here - we can compute via an arbitrary number of pieces of codemirror state to derive the different options
3. I'm starting to think about a better way to mount the minimap into the editor. Before it was too opaque, we created a dom node for you internally that you had no control over and mounted it into the editor somewhere. Now, you provide the dom node. We still mount it for you - because I need to think a little more about if it would truly be better for the callsite to handle mounting it. `showPanel` also mounts it for you, so I tend to think that's the right approach. But in replit we need a better way to let right gutters configure their order - we want to show thread indicators to the left of the minimap, which is why we might need to let you mount the node yourself. I think ideally we release a right gutter api where that ordering is configurable and this hooks into that.


Test plan:
* I've pulled this up in the test harness and everything works well, including mounting and unmounting. I'll probably pull this into replit after it's landed and test it out before cutting a release.
