### PR TITLE
Fix build and Mark 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.1 (2023-10-25)
+
+### Bug fixes
+
+Remove circular imports to fix build
+
 ## 0.5.0 (2023-10-25)
 
 ### Breaking changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/codemirror-minimap",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": {
     "name": "Brady Madden",
     "email": "brady@repl.it"

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -9,6 +9,8 @@ type EventHandler<event extends keyof DOMEventMap> = (
 ) => void;
 
 type Options = {
+  enabled: boolean;
+
   /**
    * Determines how to render text. Defaults to `characters`.
    */
@@ -27,17 +29,17 @@ type Options = {
    */
   showOverlay?: "always" | "mouse-over";
 
-  /** 
+  /**
    * Enables a gutter to be drawn on the given line to the left
    * of the minimap, with the given color. Accepts all valid CSS
    * color values.
    */
-  gutters?: Array<Gutter>
+  gutters?: Array<Gutter>;
 };
 
 const Config = Facet.define<MinimapConfig | null, Required<Options>>({
   combine: (c) => {
-    const configs: Array<Omit<MinimapConfig, 'create'>> = [];
+    const configs: Array<Options> = [];
     for (let config of c) {
       if (!config) {
         continue;
@@ -47,11 +49,15 @@ const Config = Facet.define<MinimapConfig | null, Required<Options>>({
 
       configs.push({
         ...rest,
-        gutters: gutters ? gutters.filter(v => Object.keys(v).length > 0) : undefined,
+        enabled: true,
+        gutters: gutters
+          ? gutters.filter((v) => Object.keys(v).length > 0)
+          : undefined,
       });
     }
 
     return combineConfig(configs, {
+      enabled: configs.length > 0,
       displayText: "characters",
       eventHandlers: {},
       showOverlay: "always",

--- a/src/LinesState.ts
+++ b/src/LinesState.ts
@@ -1,13 +1,13 @@
 import { foldEffect, foldedRanges, unfoldEffect } from "@codemirror/language";
 import { StateField, EditorState, Transaction } from "@codemirror/state";
-import { showMinimap } from ".";
+import { Config } from "./Config";
 
 type Span = { from: number; to: number; folded: boolean };
 type Line = Array<Span>;
 type Lines = Array<Line>;
 
 function computeLinesState(state: EditorState): Lines {
-  if (!state.facet(showMinimap)) {
+  if (!state.facet(Config).enabled) {
     return [];
   }
 

--- a/src/Overlay.ts
+++ b/src/Overlay.ts
@@ -1,7 +1,6 @@
 import { EditorView, ViewPlugin, ViewUpdate } from "@codemirror/view";
 import { Config, Scale } from "./Config";
 import crelt from "crelt";
-import { showMinimap } from ".";
 
 const Theme = EditorView.theme({
   ".cm-minimap-overlay-container": {
@@ -54,8 +53,8 @@ const OverlayView = ViewPlugin.fromClass(
     private _dragStartY: number | undefined;
 
     public constructor(private view: EditorView) {
-      if (view.state.facet(showMinimap)) {
-        this.create(view)
+      if (view.state.facet(Config).enabled) {
+        this.create(view);
       }
     }
 
@@ -91,8 +90,8 @@ const OverlayView = ViewPlugin.fromClass(
     }
 
     update(update: ViewUpdate) {
-      const prev = update.startState.facet(showMinimap);
-      const now = update.state.facet(showMinimap);
+      const prev = update.startState.facet(Config).enabled;
+      const now = update.state.facet(Config).enabled;
 
       if (prev && !now) {
         this.remove();

--- a/src/index.ts
+++ b/src/index.ts
@@ -267,8 +267,8 @@ const minimapClass = ViewPlugin.fromClass(
   }
 );
 
-export interface MinimapConfig extends Options {
-  /** 
+export interface MinimapConfig extends Omit<Options, "enabled"> {
+  /**
    * A function that creates the element that contains the minimap
    */
   create: (view: EditorView) => { dom: HTMLElement };


### PR DESCRIPTION
i had some circular references in the previous build that broke repl-it-web build. This just refactors the code to remove them.