### PR TITLE
Don't update minimap when its not showing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/codemirror-minimap",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": {
     "name": "Brady Madden",
     "email": "brady@repl.it"

--- a/src/Overlay.ts
+++ b/src/Overlay.ts
@@ -99,20 +99,22 @@ const OverlayView = ViewPlugin.fromClass(
       }
 
       if (!prev && now) {
-        this.create(update.view)
+        this.create(update.view);
       }
 
-      this.computeShowOverlay();
+      if (now) {
+        this.computeShowOverlay();
 
-      if (update.geometryChanged) {
-        this.computeHeight();
-        this.computeTop();
+        if (update.geometryChanged) {
+          this.computeHeight();
+          this.computeTop();
+        }
       }
     }
 
     public computeHeight() {
       if (!this.dom) {
-        return
+        return;
       }
 
       const height = this.view.dom.clientHeight / SCALE;

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -9,6 +9,7 @@ import {
 import { LineBasedState } from "./linebasedstate";
 import { DrawContext } from "./types";
 import { Lines, LinesState, foldsChanged } from "./LinesState";
+import { Config } from "./Config";
 
 type Severity = Diagnostic["severity"];
 
@@ -20,6 +21,11 @@ export class DiagnosticState extends LineBasedState<Severity> {
   }
 
   private shouldUpdate(update: ViewUpdate) {
+    // If the minimap is disabled
+    if (!update.state.facet(Config).enabled) {
+      return false;
+    }
+
     // If the doc changed
     if (update.docChanged) {
       return true;
@@ -131,8 +137,8 @@ export class DiagnosticState extends LineBasedState<Severity> {
     return severity === "error"
       ? "#d11"
       : severity === "warning"
-        ? "orange"
-        : "#999";
+      ? "orange"
+      : "#999";
   }
 
   /** Sorts severity from most to least severe */

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,22 +55,22 @@ const minimapClass = ViewPlugin.fromClass(
       this.diagnostic = diagnostics(view);
 
       if (view.state.facet(showMinimap)) {
-        this.create(view)
+        this.create(view);
       }
     }
 
     private create(view: EditorView) {
-      const config = view.state.facet(showMinimap)
+      const config = view.state.facet(showMinimap);
       if (!config) {
-        throw Error('Expected nonnull');
+        throw Error("Expected nonnull");
       }
 
       this.inner = crelt("div", { class: "cm-minimap-inner" });
       this.canvas = crelt("canvas") as HTMLCanvasElement;
 
       this.dom = config.create(view).dom;
-      this.dom.classList.add('cm-gutters');
-      this.dom.classList.add('cm-minimap-gutter');
+      this.dom.classList.add("cm-gutters");
+      this.dom.classList.add("cm-minimap-gutter");
 
       this.inner.appendChild(this.canvas);
       this.dom.appendChild(this.inner);
@@ -82,7 +82,6 @@ const minimapClass = ViewPlugin.fromClass(
         this.dom,
         this.view.contentDOM.nextSibling
       );
-
 
       for (const key in this.view.state.facet(Config).eventHandlers) {
         const handler = this.view.state.facet(Config).eventHandlers[key];
@@ -108,13 +107,15 @@ const minimapClass = ViewPlugin.fromClass(
       }
 
       if (!prev && now) {
-        this.create(update.view)
+        this.create(update.view);
       }
 
-      this.text.update(update);
-      this.selection.update(update);
-      this.diagnostic.update(update);
-      this.render();
+      if (now) {
+        this.text.update(update);
+        this.selection.update(update);
+        this.diagnostic.update(update);
+        this.render();
+      }
     }
 
     getWidth(): number {
@@ -245,7 +246,7 @@ const minimapClass = ViewPlugin.fromClass(
     }
 
     destroy() {
-      this.remove()
+      this.remove();
     }
   },
   {
@@ -274,15 +275,14 @@ export interface MinimapConfig extends Omit<Options, "enabled"> {
   create: (view: EditorView) => { dom: HTMLElement };
 }
 
-
-/** 
+/**
  * Facet used to show a minimap in the right gutter of the editor using the
  * provided configuration.
- * 
+ *
  * If you return `null`, a minimap will not be shown.
  */
 const showMinimap = Facet.define<MinimapConfig | null, MinimapConfig | null>({
-  combine: (c) => c.find(o => o !== null) ?? null,
+  combine: (c) => c.find((o) => o !== null) ?? null,
   enables: (f) => {
     return [
       [
@@ -291,9 +291,9 @@ const showMinimap = Facet.define<MinimapConfig | null, MinimapConfig | null>({
         LinesState,
         minimapClass, // TODO, codemirror-ify this one better
         Overlay,
-      ]
-    ]
-  }
-})
+      ],
+    ];
+  },
+});
 
 export { showMinimap };

--- a/src/selections.ts
+++ b/src/selections.ts
@@ -2,6 +2,7 @@ import { LineBasedState } from "./linebasedstate";
 import { EditorView, ViewUpdate } from "@codemirror/view";
 import { LinesState, foldsChanged } from "./LinesState";
 import { DrawContext } from "./types";
+import { Config } from "./Config";
 
 type Selection = { from: number; to: number; extends: boolean };
 type DrawInfo = { backgroundColor: string };
@@ -18,6 +19,11 @@ export class SelectionState extends LineBasedState<Array<Selection>> {
   }
 
   private shouldUpdate(update: ViewUpdate) {
+    // If the minimap is disabled
+    if (!update.state.facet(Config).enabled) {
+      return false;
+    }
+
     // If the doc changed
     if (update.docChanged) {
       return true;
@@ -45,6 +51,7 @@ export class SelectionState extends LineBasedState<Array<Selection>> {
     if (!this.shouldUpdate(update)) {
       return;
     }
+
     this.map.clear();
 
     /* If class list has changed, clear and recalculate the selection style */
@@ -142,7 +149,7 @@ export class SelectionState extends LineBasedState<Array<Selection>> {
       lineHeight,
       charWidth,
       offsetX: startOffsetX,
-      offsetY
+      offsetY,
     } = ctx;
     const selections = this.get(lineNumber);
     if (!selections) {

--- a/src/text.ts
+++ b/src/text.ts
@@ -23,7 +23,10 @@ export class TextState extends LineBasedState<Array<TagSpan>> {
     super(view);
 
     this._themeClasses = new Set(view.dom.classList.values());
-    this.updateImpl(view.state);
+
+    if (view.state.facet(Config).enabled) {
+      this.updateImpl(view.state);
+    }
   }
 
   private shouldUpdate(update: ViewUpdate) {


### PR DESCRIPTION
Adding some additional checks to prevent some of the expensive minimap code from running when it is disabled. This seems like it was an oversight from the previous PR.