### PR TITLE
Allow autohiding of minimap

### DIFF
--- a/.replit
+++ b/.replit
@@ -11,3 +11,7 @@ channel = "stable-22_11"
 build = ["sh", "-c", "mkdir .build && bun build index.ts > .build/index.js"]
 run = ["bun", ".build/index.js"]
 deploymentTarget = "cloudrun"
+
+[[ports]]
+localPort = 5173
+externalPort = 80

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -9,6 +9,12 @@ type EventHandler<event extends keyof DOMEventMap> = (
 ) => void;
 
 type Options = {
+  /** 
+   * Controls whether the minimap should be hidden on mouseout.
+   * Defaults to `false`.
+   */
+  autohide?: boolean;
+
   enabled: boolean;
 
   /**
@@ -62,6 +68,7 @@ const Config = Facet.define<MinimapConfig | null, Required<Options>>({
       eventHandlers: {},
       showOverlay: "always",
       gutters: [],
+      autohide: false,
     });
   },
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,13 @@ const Theme = EditorView.theme({
     right: 0,
     top: 0,
   },
+  '& .cm-minimap-autohide': {
+    opacity: 0.0,
+    transition: 'opacity 0.3s',
+  },
+  '& .cm-minimap-autohide:hover': {
+    opacity: 1.0,
+  },
   "& .cm-minimap-inner": {
     height: "100%",
     position: "absolute",
@@ -88,6 +95,10 @@ const minimapClass = ViewPlugin.fromClass(
         if (handler) {
           this.dom.addEventListener(key, (e) => handler(e, this.view));
         }
+      }
+
+      if (config.autohide) {
+        this.dom.classList.add('cm-minimap-autohide');
       }
     }
 


### PR DESCRIPTION
Adds an `autohide` option to match vscode's behavior of showing/hiding the minimap on mouse in/out.

Addresses #37 